### PR TITLE
Change default value of innodb_empty_free_list_algorithm to 'legacy'.

### DIFF
--- a/mysql-test/suite/sys_vars/r/innodb_empty_free_list_algorithm_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_empty_free_list_algorithm_basic.result
@@ -1,7 +1,7 @@
 SET @start_value = @@GLOBAL.innodb_empty_free_list_algorithm;
 SELECT @@GLOBAL.innodb_empty_free_list_algorithm;
 @@GLOBAL.innodb_empty_free_list_algorithm
-backoff
+legacy
 SELECT @@SESSION.innodb_empty_free_list_algorithm;
 ERROR HY000: Variable 'innodb_empty_free_list_algorithm' is a GLOBAL variable
 SET GLOBAL innodb_empty_free_list_algorithm='legacy';

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -18175,9 +18175,9 @@ static MYSQL_SYSVAR_ENUM(empty_free_list_algorithm,
   srv_empty_free_list_algorithm,
   PLUGIN_VAR_OPCMDARG,
   "The algorithm to use for empty free list handling.  Allowed values: "
-  "LEGACY: Original Oracle MySQL 5.6 handling with single page flushes; "
-  "BACKOFF: (default) Wait until cleaner produces a free page.",
-  innodb_srv_empty_free_list_algorithm_validate, NULL, SRV_EMPTY_FREE_LIST_BACKOFF,
+  "LEGACY: (default) Original Oracle MySQL 5.6 handling with single page flushes; "
+  "BACKOFF: Wait until cleaner produces a free page.",
+  innodb_srv_empty_free_list_algorithm_validate, NULL, SRV_EMPTY_FREE_LIST_LEGACY,
   &innodb_empty_free_list_algorithm_typelib);
 
 static MYSQL_SYSVAR_LONG(buffer_pool_instances, innobase_buffer_pool_instances,


### PR DESCRIPTION
Summary:
Recently we ported Facebook MySQL LRA and AIO enhancement patches.
As part of testing InnoDB AIO stalls were uncovered in Percona Server
that can be specifically linked to PS feature
innodb_empty_free_list_algorithm=backoff.

There are two implementations of innodb_empty_free_list_algorithm:

backoff = Percona implementation
legacy = upstream MySQL implementation

When the stall happens, it can be pretty clearly seen from the InnoDB status:

```
Pending normal aio reads: 10532 [64, 128, 128, 128, 64, 192, 192, 192, 128, 192, 192, 128, 192, 192, 192, 192, 192, 128, 64, 128, 192, 192, 192, 192, 192, 192, 192, 192, 192, 192, 128, 192, 128, 192, 192, 128, 192, 192, 192, 192, 192,
 128, 128, 192, 192, 192, 192, 192, 192, 128, 128, 192, 128, 192, 128, 192, 192, 128, 128, 192, 192, 164, 128, 64] , aio writes: 0 [0, 0, 0, 0] ,
    dynamically switching to innodb_empty_free_list_algorithm=legacy frees up the slots

Pending normal aio reads: 0 [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] , aio writes:
 0 [0, 0, 0, 0] ,
```

Reverting to innodb_empty_free_list_algorithm=legacy fixes the stall.

Test Plan: Modified the test sys_vars.sys_vars/r/innodb_empty_free_list_algorithm_basic

Reviewers: firsov